### PR TITLE
Use interfaces rather than references to interfaces

### DIFF
--- a/pkg/client/main.go
+++ b/pkg/client/main.go
@@ -48,7 +48,7 @@ func (m *Malcolm) addProxy(protocol string, url string, out string) error {
 				if err != nil {
 					fmt.Println(err)
 				}
-				c := proxy.New(&connFrom, &connTo)
+				c := proxy.New(connFrom, connTo)
 				c.Proxy()
 			}
 		}

--- a/pkg/proxy/main.go
+++ b/pkg/proxy/main.go
@@ -4,7 +4,7 @@ import (
 	"net"
 )
 
-func New(from *net.Conn, to *net.Conn) *Proxy {
+func New(from net.Conn, to net.Conn) *Proxy {
 	return &Proxy{
 		From: from,
 		To:   to,
@@ -13,26 +13,26 @@ func New(from *net.Conn, to *net.Conn) *Proxy {
 }
 
 type Proxy struct {
-	From *net.Conn
-	To   *net.Conn
+	From net.Conn
+	To   net.Conn
 	End  chan (bool)
 }
 
-func (p *Proxy) monoconn(connFrom *net.Conn, connTo *net.Conn) {
+func (p *Proxy) monoconn(connFrom net.Conn, connTo net.Conn) {
 	buff := make([]byte, 0xffff) // 64kb buffer
 	for {
-		n, err := (*connFrom).Read(buff)
+		n, err := connFrom.Read(buff)
 		if err != nil {
 			// Includes io.EOF
 			p.End <- true
 		}
 		b := buff[:n]
-		n, err = (*connTo).Write(b)
+		n, err = connTo.Write(b)
 	}
 }
 
 func (p *Proxy) Proxy() {
-	defer (*p.From).Close()
+	defer p.From.Close()
 	go p.monoconn(p.From, p.To)
 	go p.monoconn(p.To, p.From)
 	<-p.End


### PR DESCRIPTION
Seems to be a bit faster in my completely non-scientific test and is a bit more idiomatic